### PR TITLE
Feature: Auton Dead Reckon

### DIFF
--- a/src/edu/stuy/Robot.java
+++ b/src/edu/stuy/Robot.java
@@ -58,14 +58,11 @@ public class Robot extends IterativeRobot {
     private void setupAutonChooser() {
         autonChooser = new SendableChooser();
         autonChooser.addDefault("1. Do nothing", new CommandGroup());
-        autonChooser.addObject("2. Drive forward from Driver Side", new AutonDriveForwardInchesCommand(AUTON_DRIVE_FORWARD_DRIVER_SIDE));
+        autonChooser.addObject("2. Drive forward from Driver Side", new AutonDriveForwardInchesCommand(AUTON_DRIVE_FORWARD_DRIVER_SIDE, AUTON_DRIVE_FROM_DRIVER_SIDE_TIMEOUT));
         // Driving forward from Field Side means we are doing a mobility auton routine without pushing totes
-        autonChooser.addObject("3. Drive forward from Field Side", new AutonDriveForwardInchesCommand(AUTON_DRIVE_FORWARD_FIELD_SIDE));
-        // -1 means that AutonDriveForwardInches uses INCHES_LABEL. Defers reading of Smartdashboard value until auton starts
-        autonChooser.addObject("4. Drive forward Custom Amount", new AutonDriveForwardInchesCommand(-1));
+        autonChooser.addObject("3. Drive forward from Field Side", new AutonDriveForwardInchesCommand(AUTON_DRIVE_FORWARD_FIELD_SIDE, AUTON_DRIVE_FROM_FIELD_SIDE_TIMEOUT));
         autonChooser.addObject("5. Acquires set and drives forward (Currently doing PID tuning)", new AutonOneSetCommand());
         SmartDashboard.putData("Auton setting", autonChooser);
-        SmartDashboard.putNumber(INCHES_LABEL, -1);
         SmartDashboard.putNumber(PID_TUNING_P, DRIVE_ROTATE_P);
         SmartDashboard.putNumber(PID_TUNING_I, DRIVE_ROTATE_I);
         SmartDashboard.putNumber(PID_TUNING_D, DRIVE_ROTATE_D);

--- a/src/edu/stuy/Robot.java
+++ b/src/edu/stuy/Robot.java
@@ -61,8 +61,10 @@ public class Robot extends IterativeRobot {
         autonChooser.addObject("2. Drive forward from Driver Side", new AutonDriveForwardInchesCommand(AUTON_DRIVE_FORWARD_DRIVER_SIDE, AUTON_DRIVE_FROM_DRIVER_SIDE_TIMEOUT));
         // Driving forward from Field Side means we are doing a mobility auton routine without pushing totes
         autonChooser.addObject("3. Drive forward from Field Side", new AutonDriveForwardInchesCommand(AUTON_DRIVE_FORWARD_FIELD_SIDE, AUTON_DRIVE_FROM_FIELD_SIDE_TIMEOUT));
+        autonChooser.addObject("4. Custom timeout (testing only)", new AutonDriveForwardInchesCommand(-1, -1));
         autonChooser.addObject("5. Acquires set and drives forward (Currently doing PID tuning)", new AutonOneSetCommand());
         SmartDashboard.putData("Auton setting", autonChooser);
+        SmartDashboard.putNumber(TIMEOUT_LABEL, -1);
         SmartDashboard.putNumber(PID_TUNING_P, DRIVE_ROTATE_P);
         SmartDashboard.putNumber(PID_TUNING_I, DRIVE_ROTATE_I);
         SmartDashboard.putNumber(PID_TUNING_D, DRIVE_ROTATE_D);

--- a/src/edu/stuy/RobotMap.java
+++ b/src/edu/stuy/RobotMap.java
@@ -78,7 +78,7 @@ public interface RobotMap {
     
     //Displayed on Smart Dashboard
     String INCHES_LABEL = "If you are using Setting 4, then input number of inches";
-    String TIMEOUT_LABEL = "If you are using Setting 4,, then input number of seconds";
+    String TIMEOUT_LABEL = "If you are using Setting 4, then input number of seconds";
     String PID_TUNING_P = "PID: p";
     String PID_TUNING_I = "PID: i";
     String PID_TUNING_D = "PID: d";

--- a/src/edu/stuy/RobotMap.java
+++ b/src/edu/stuy/RobotMap.java
@@ -53,11 +53,11 @@ public interface RobotMap {
     
     // Auton Constants
     double DRIVETRAIN_ROTATE_THRESHOLD_DEGREES = 5.0;
-    double AUTON_ONE_SET_DRIVE_INCHES_FIRST = 25.0;
+    double AUTON_ONE_SET_DRIVE_INCHES_FIRST = 14.0;
     double AUTON_ONE_SET_ROTATE_DEGREES = 90.0;
     double AUTON_ONE_SET_DRIVE_INCHES_SECOND = 112.0; //If this is changed, also change AUTON_DRIVE_FORWARD_FIELD_SIDE
     double AUTON_ACQUIRE_TIME = 1;
-    double AUTON_DRIVETRAIN_TIMEOUT = 5;
+    double AUTON_DRIVETRAIN_TIMEOUT_MULTIPLIER = .02;
     double AUTON_LIFT_TIMEOUT = 5;
 
     // Tote Dimensions (inches)

--- a/src/edu/stuy/RobotMap.java
+++ b/src/edu/stuy/RobotMap.java
@@ -53,9 +53,11 @@ public interface RobotMap {
     
     // Auton Constants
     double DRIVETRAIN_ROTATE_THRESHOLD_DEGREES = 5.0;
-    double AUTON_ONE_SET_DRIVE_INCHES_FIRST = 14.0;
-    double AUTON_ONE_SET_ROTATE_DEGREES = 90.0;
+    double AUTON_ONE_SET_DRIVE_INCHES_FIRST =10.0;
+    double AUTON_ONE_SET_DRIVE_INCHES_FIRST_TIMEOUT = 1;
     double AUTON_ONE_SET_DRIVE_INCHES_SECOND = 112.0; //If this is changed, also change AUTON_DRIVE_FORWARD_FIELD_SIDE
+    double AUTON_ONE_SET_DRIVE_INCHES_SECOND_TIMEOUT = .02 * AUTON_ONE_SET_DRIVE_INCHES_SECOND;
+    double AUTON_ONE_SET_ROTATE_DEGREES = 90.0;
     double AUTON_ACQUIRE_TIME = 1;
     double AUTON_DRIVETRAIN_TIMEOUT_MULTIPLIER = .02;
     double AUTON_LIFT_TIMEOUT = 5;
@@ -71,6 +73,9 @@ public interface RobotMap {
     double AUTON_DRIVE_FORWARD_FIELD_SIDE = 112.0; //If this is changed, also change AUTON_ONE_SET_DRIVE_INCHES_SECOND
     double AUTON_DRIVE_FORWARD_DRIVER_SIDE = AUTON_DRIVE_FORWARD_FIELD_SIDE
             + TOTE_WIDTH + ROBOT_LENGTH;
+    double AUTON_DRIVE_FROM_DRIVER_SIDE_TIMEOUT = AUTON_ONE_SET_DRIVE_INCHES_SECOND_TIMEOUT;
+    double AUTON_DRIVE_FROM_FIELD_SIDE_TIMEOUT = .02 * AUTON_DRIVE_FORWARD_FIELD_SIDE;
+    
     //Displayed on Smart Dashboard
     String INCHES_LABEL = "If you are using Setting 4, then input number of inches";
     String PID_TUNING_P = "PID: p";

--- a/src/edu/stuy/RobotMap.java
+++ b/src/edu/stuy/RobotMap.java
@@ -78,6 +78,7 @@ public interface RobotMap {
     
     //Displayed on Smart Dashboard
     String INCHES_LABEL = "If you are using Setting 4, then input number of inches";
+    String TIMEOUT_LABEL = "If you are using Setting 4,, then input number of seconds";
     String PID_TUNING_P = "PID: p";
     String PID_TUNING_I = "PID: i";
     String PID_TUNING_D = "PID: d";

--- a/src/edu/stuy/commands/auton/AutonDriveForwardInchesCommand.java
+++ b/src/edu/stuy/commands/auton/AutonDriveForwardInchesCommand.java
@@ -1,8 +1,10 @@
 package edu.stuy.commands.auton;
 
+import static edu.stuy.RobotMap.*;
 import edu.stuy.Robot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 /**
  *
  */
@@ -12,6 +14,7 @@ public class AutonDriveForwardInchesCommand extends Command {
     private double inches;
     private double startTime;
     private double timeout;
+    private boolean usingCustomTimeout;
     
     /** 
      * If distance < 0, get it from SmartDashboard
@@ -23,6 +26,7 @@ public class AutonDriveForwardInchesCommand extends Command {
         // eg. requires(chassis);
         inches = dist;
         timeout = seconds;
+        usingCustomTimeout = dist < 0;
         requires(Robot.drivetrain);
     }
 
@@ -33,6 +37,9 @@ public class AutonDriveForwardInchesCommand extends Command {
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
+        if (usingCustomTimeout) {
+            timeout = SmartDashboard.getNumber(TIMEOUT_LABEL);
+        }
         double speed = getRampSpeed();
         Robot.drivetrain.tankDrive(speed, speed);
     }

--- a/src/edu/stuy/commands/auton/AutonDriveForwardInchesCommand.java
+++ b/src/edu/stuy/commands/auton/AutonDriveForwardInchesCommand.java
@@ -30,6 +30,7 @@ public class AutonDriveForwardInchesCommand extends Command {
     // Called just before this Command runs the first time
     protected void initialize() {
         startTime = Timer.getFPGATimestamp();
+        //Robot.drivetrain.resetEncoders();
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -63,7 +64,7 @@ public class AutonDriveForwardInchesCommand extends Command {
 
     // Make this return true when this Command no longer needs to run execute()
     protected boolean isFinished() {
-        return Robot.drivetrain.getDistance() >= inches || Timer.getFPGATimestamp() - startTime >= AUTON_DRIVETRAIN_TIMEOUT;
+        return Timer.getFPGATimestamp() - startTime >= inches * AUTON_DRIVETRAIN_TIMEOUT_MULTIPLIER;
     }
 
     // Called once after isFinished returns true

--- a/src/edu/stuy/commands/auton/AutonDriveForwardInchesCommand.java
+++ b/src/edu/stuy/commands/auton/AutonDriveForwardInchesCommand.java
@@ -1,43 +1,38 @@
 package edu.stuy.commands.auton;
 
-import static edu.stuy.RobotMap.*;
 import edu.stuy.Robot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.command.Command;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 /**
  *
  */
 public class AutonDriveForwardInchesCommand extends Command {
 
+    // inches is unused; we are keeping it to know how far we were intending to go
     private double inches;
     private double startTime;
-    private boolean usingCustomDistance;
+    private double timeout;
     
     /** 
      * If distance < 0, get it from SmartDashboard
      * @param dist
      */
 
-    public AutonDriveForwardInchesCommand(double dist) {
+    public AutonDriveForwardInchesCommand(double dist, double seconds) {
         // Use requires() here to declare subsystem dependencies
         // eg. requires(chassis);
-        usingCustomDistance = dist < 0;
         inches = dist;
+        timeout = seconds;
         requires(Robot.drivetrain);
     }
 
     // Called just before this Command runs the first time
     protected void initialize() {
         startTime = Timer.getFPGATimestamp();
-        //Robot.drivetrain.resetEncoders();
     }
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
-        if (usingCustomDistance) {
-            inches = SmartDashboard.getNumber(INCHES_LABEL);
-        }
         double speed = getRampSpeed();
         Robot.drivetrain.tankDrive(speed, speed);
     }
@@ -64,7 +59,7 @@ public class AutonDriveForwardInchesCommand extends Command {
 
     // Make this return true when this Command no longer needs to run execute()
     protected boolean isFinished() {
-        return Timer.getFPGATimestamp() - startTime >= inches * AUTON_DRIVETRAIN_TIMEOUT_MULTIPLIER;
+        return Timer.getFPGATimestamp() - startTime >= timeout;
     }
 
     // Called once after isFinished returns true

--- a/src/edu/stuy/commands/auton/AutonOneSetCommand.java
+++ b/src/edu/stuy/commands/auton/AutonOneSetCommand.java
@@ -22,10 +22,10 @@ public class AutonOneSetCommand extends CommandGroup {
         addSequential(new ArmsNarrowCommand());
         addSequential(new AutonAcquirerCommand());
         addSequential(new AutonLiftUpCommand());
-        addSequential(new AutonDriveForwardInchesCommand(AUTON_ONE_SET_DRIVE_INCHES_FIRST));
+        addSequential(new AutonDriveForwardInchesCommand(AUTON_ONE_SET_DRIVE_INCHES_FIRST, AUTON_ONE_SET_DRIVE_INCHES_FIRST_TIMEOUT));
         addSequential(new AutonAcquirerCommand());
         addSequential(new DrivetrainRotateCommand(AUTON_ONE_SET_ROTATE_DEGREES, p, i, d));
-        addSequential(new AutonDriveForwardInchesCommand(AUTON_ONE_SET_DRIVE_INCHES_SECOND));
+        addSequential(new AutonDriveForwardInchesCommand(AUTON_ONE_SET_DRIVE_INCHES_SECOND, AUTON_ONE_SET_DRIVE_INCHES_SECOND_TIMEOUT));
 
         // To run multiple commands at the same time,
         // use addParallel()


### PR DESCRIPTION
We changed the auton mobilities commands to work only by time and not rely on encoders. We also added an input to SmartDashboard that allows you to enter a custom timeout amount which is only for testing (use auton 4 to test). The timeouts set for auton have not been tested yet. 
